### PR TITLE
feat: twitter-textライブラリによる厳密な文字数カウントに変更

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,8 +81,12 @@
     }, 2000);
   }
 
-  // --- Character count (X spec: U+0000-U+10FF = 1, U+1100+ = 2) ---
+  // --- Character count (twitter-text parseTweet準拠) ---
   function countWeightedChars(text) {
+    if (typeof twttr !== 'undefined' && twttr.txt && twttr.txt.parseTweet) {
+      return twttr.txt.parseTweet(text).weightedLength;
+    }
+    // フォールバック: ライブラリ未読み込み時は単純な長さを返す
     var count = 0;
     for (var i = 0; i < text.length; i++) {
       var cp = text.codePointAt(i);

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
       <div class="settings-item">
         <div class="settings-item-label">
           <div class="settings-item-title">文字数カウント表示</div>
-          <div class="settings-item-desc">メモ編集中に文字数を表示します（twitter-textライブラリ準拠）</div>
+          <div class="settings-item-desc">メモ編集中に文字数を表示します（X準拠）</div>
         </div>
         <label class="toggle">
           <input type="checkbox" id="setting-charcount">

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
       <div class="settings-item">
         <div class="settings-item-label">
           <div class="settings-item-title">文字数カウント表示</div>
-          <div class="settings-item-desc">メモ編集中に文字数を表示します（X準拠：半角1、全角2）</div>
+          <div class="settings-item-desc">メモ編集中に文字数を表示します（twitter-textライブラリ準拠）</div>
         </div>
         <label class="toggle">
           <input type="checkbox" id="setting-charcount">
@@ -88,6 +88,7 @@
     </div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/twitter-text@3.1.0/dist/twitter-text.min.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-var CACHE_NAME = 'url-memo-v3';
+var CACHE_NAME = 'url-memo-v4';
 var ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
CDN経由でtwitter-text v3.1.0を読み込み、parseTweet().weightedLengthで
Twitter/X準拠の正確な文字数カウントを行うように変更。URLが固定長(23文字)で
カウントされるなど、実際のTwitterの仕様に合致するようになる。
ライブラリ未読み込み時のフォールバックも維持。

https://claude.ai/code/session_01Hi6mUhNdM8U4k1umr6pjCw