### PR TITLE
fix: モバイルキーボード表示時に編集画面のレイアウトが崩れる問題を修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@
   'use strict';
 
   // --- Constants ---
-  const APP_VERSION = '1.5.0';
+  const APP_VERSION = '1.5.1';
   const STORAGE_KEY = 'url_memo_data';
   const SETTINGS_KEY = 'url_memo_settings';
 

--- a/app.js
+++ b/app.js
@@ -113,6 +113,7 @@
   // --- View switching ---
   function showListView() {
     editView.classList.add('hidden');
+    editView.style.height = '';
     settingsView.classList.add('hidden');
     listView.classList.remove('hidden');
     currentMemoId = null;
@@ -448,6 +449,24 @@
     updateCharCount();
 
     return true;
+  }
+
+  // --- Visual Viewport handling (モバイルキーボード対応) ---
+  function handleViewportResize() {
+    if (editView.classList.contains('hidden')) return;
+    if (window.visualViewport) {
+      editView.style.height = window.visualViewport.height + 'px';
+      window.scrollTo(0, 0);
+    }
+  }
+
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', handleViewportResize);
+    window.visualViewport.addEventListener('scroll', function () {
+      if (!editView.classList.contains('hidden') && window.visualViewport.offsetTop > 0) {
+        window.scrollTo(0, 0);
+      }
+    });
   }
 
   // --- Service Worker registration ---

--- a/style.css
+++ b/style.css
@@ -34,6 +34,13 @@ html, body {
   flex-direction: column;
 }
 
+#edit-view {
+  height: 100vh;
+  height: 100dvh;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .hidden {
   display: none !important;
 }
@@ -228,7 +235,7 @@ header h1 {
 
 #memo-text {
   flex: 1;
-  min-height: 200px;
+  min-height: 80px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 16px;

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-var CACHE_NAME = 'url-memo-v1.5.0';
+var CACHE_NAME = 'url-memo-v1.5.1';
 var ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
- #edit-view に dvh 単位 (100vh フォールバック付き) を使用し、キーボード表示時に ビューポート高さに追従するよう変更
- textarea の min-height を 200px から 80px に縮小し、キーボード表示時にも ボタンがビューポート内に収まるよう調整
- visualViewport API でキーボードの開閉を検知し、編集画面の高さを動的に調整
- ページスクロールのオフセットを防止し、入力欄とボタンが常に表示されるよう対応

https://claude.ai/code/session_01S3xV4i2EnGtMSk8qTVcnfA