### PR TITLE
Replace edit-on-share toggle with quick-share action selector

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@
   'use strict';
 
   // --- Constants ---
-  const APP_VERSION = '1.6.0';
+  const APP_VERSION = '1.7.0';
   const STORAGE_KEY = 'url_memo_data';
   const SETTINGS_KEY = 'url_memo_settings';
 
@@ -24,11 +24,21 @@
   }
 
   function loadSettings() {
+    var defaults = { addNewlineAfterUrl: false, showCharCount: false, quickShareAction: 'ask' };
     try {
       var raw = localStorage.getItem(SETTINGS_KEY);
-      return raw ? JSON.parse(raw) : { addNewlineAfterUrl: false, showCharCount: false, editOnShare: false };
+      if (!raw) return defaults;
+      var parsed = JSON.parse(raw);
+      // editOnShare (旧設定) からの移行
+      if ('editOnShare' in parsed && !('quickShareAction' in parsed)) {
+        parsed.quickShareAction = parsed.editOnShare ? 'edit' : 'ask';
+        delete parsed.editOnShare;
+        saveSettings(parsed);
+      }
+      if (!parsed.quickShareAction) parsed.quickShareAction = 'ask';
+      return parsed;
     } catch {
-      return { addNewlineAfterUrl: false, showCharCount: false, editOnShare: false };
+      return defaults;
     }
   }
 
@@ -64,7 +74,7 @@
   const settingsView = document.getElementById('settings-view');
   const btnSettings = document.getElementById('btn-settings');
   const btnSettingsBack = document.getElementById('btn-settings-back');
-  const settingEditOnShare = document.getElementById('setting-edit-on-share');
+  const settingQuickShareAction = document.getElementById('setting-quick-share-action');
   const settingNewline = document.getElementById('setting-newline');
   const settingCharcount = document.getElementById('setting-charcount');
   const charCountEl = document.getElementById('char-count');
@@ -149,7 +159,7 @@
     editView.classList.add('hidden');
     settingsView.classList.remove('hidden');
     var settings = loadSettings();
-    settingEditOnShare.checked = settings.editOnShare;
+    settingQuickShareAction.value = settings.quickShareAction || 'ask';
     settingNewline.checked = settings.addNewlineAfterUrl;
     settingCharcount.checked = settings.showCharCount;
     appVersionEl.textContent = 'URL Memo v' + APP_VERSION;
@@ -399,9 +409,10 @@
     showListView();
   });
 
-  settingEditOnShare.addEventListener('change', function () {
+  settingQuickShareAction.addEventListener('change', function () {
     var settings = loadSettings();
-    settings.editOnShare = settingEditOnShare.checked;
+    settings.quickShareAction = settingQuickShareAction.value;
+    delete settings.editOnShare;
     saveSettings(settings);
   });
 
@@ -513,14 +524,16 @@
     }
 
     var settings = loadSettings();
-    if (settings.editOnShare) {
-      // Current behavior: open edit view
+    var action = settings.quickShareAction || 'ask';
+
+    if (action === 'edit') {
+      // 編集画面を開く
       showEditView(null);
       memoText.value = initialText;
       editTitle.textContent = '新規メモ';
       updateCharCount();
     } else {
-      // Quick share: save memo and show action sheet
+      // まずメモを保存
       var memos = loadMemos();
       var now = Date.now();
       memos.push({
@@ -530,7 +543,28 @@
         updatedAt: now
       });
       saveMemos(memos);
-      showQuickShareDialog(initialText);
+
+      if (action === 'postX') {
+        // 直接Xにポスト
+        var xUrl = 'https://x.com/intent/tweet?text=' + encodeURIComponent(initialText);
+        window.open(xUrl, '_blank');
+        showListView();
+      } else if (action === 'reshare') {
+        // 直接他のアプリに共有
+        if (navigator.share) {
+          navigator.share({ text: initialText }).then(function () {
+            showListView();
+          }).catch(function () {
+            showListView();
+          });
+        } else {
+          showToast('この環境では共有機能を使用できません');
+          showListView();
+        }
+      } else {
+        // ask: アクション選択ダイアログを表示
+        showQuickShareDialog(initialText);
+      }
     }
 
     return true;

--- a/index.html
+++ b/index.html
@@ -52,15 +52,17 @@
       <h1>設定</h1>
     </header>
     <div class="settings-container">
-      <div class="settings-item">
+      <div class="settings-item settings-item-vertical">
         <div class="settings-item-label">
-          <div class="settings-item-title">共有時にテキストを編集</div>
-          <div class="settings-item-desc">OFFの場合、すぐに再共有・Xポストに移行します</div>
+          <div class="settings-item-title">クイック共有の動作</div>
+          <div class="settings-item-desc">URLを受け取ったときの動作を選択します</div>
         </div>
-        <label class="toggle">
-          <input type="checkbox" id="setting-edit-on-share">
-          <span class="toggle-slider"></span>
-        </label>
+        <select id="setting-quick-share-action" class="settings-select">
+          <option value="ask">毎回選ぶ</option>
+          <option value="edit">テキストを編集する</option>
+          <option value="postX">Xにポストする</option>
+          <option value="reshare">他のアプリに共有する</option>
+        </select>
       </div>
       <div class="settings-item">
         <div class="settings-item-label">

--- a/style.css
+++ b/style.css
@@ -470,6 +470,35 @@ header h1 {
   margin-top: 4px;
 }
 
+.settings-item-vertical {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+}
+
+.settings-select {
+  width: 100%;
+  padding: 10px 12px;
+  font-size: 15px;
+  font-family: inherit;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%235f6368' d='M1.4 0L6 4.6 10.6 0 12 1.4l-6 6-6-6z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 32px;
+}
+
+.settings-select:focus {
+  border-color: var(--primary);
+}
+
 /* Toggle Switch */
 .toggle {
   position: relative;

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-var CACHE_NAME = 'url-memo-v1.6.0';
+var CACHE_NAME = 'url-memo-v1.7.0';
 var ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
This PR refactors the share behavior settings from a simple boolean toggle to a multi-option selector, allowing users to choose their preferred action when receiving a URL to share. It also includes migration logic for existing users with the old `editOnShare` setting.

## Key Changes
- **Settings UI**: Replaced the "edit on share" toggle switch with a dropdown selector offering four options:
  - "毎回選ぶ" (ask every time) - shows action dialog
  - "テキストを編集する" (edit text) - opens edit view
  - "Xにポストする" (post to X) - directly posts to X
  - "他のアプリに共有する" (reshare) - directly shares via native share API

- **Settings Migration**: Added backward compatibility logic in `loadSettings()` to automatically convert the old `editOnShare` boolean setting to the new `quickShareAction` string format

- **Share Flow**: Updated the quick share handler to support three distinct actions:
  - `edit`: Opens the edit view for manual editing
  - `postX`: Directly opens X with pre-filled text
  - `reshare`: Uses the Web Share API to share with other apps
  - `ask`: Shows the action selection dialog (default)

- **Styling**: Added new CSS classes for vertical layout settings items and styled the select dropdown with custom appearance

- **Version Bump**: Updated app version from 1.6.0 to 1.7.0

## Implementation Details
- The migration preserves user preferences by converting `editOnShare: true` → `quickShareAction: 'edit'` and `editOnShare: false` → `quickShareAction: 'ask'`
- Old `editOnShare` property is deleted after migration to keep settings clean
- Default action is set to `'ask'` for new users or if the setting is missing
- The X share URL uses `https://x.com/intent/tweet` endpoint with proper URL encoding
- Native share API includes error handling with fallback toast notification

https://claude.ai/code/session_01KsoYbw5iB2ymfURCPQZp8F