### PR TITLE
Add settings footer links and enable character count by default

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,9 +26,9 @@
   function loadSettings() {
     try {
       var raw = localStorage.getItem(SETTINGS_KEY);
-      return raw ? JSON.parse(raw) : { addNewlineAfterUrl: false, showCharCount: false, editOnShare: false };
+      return raw ? JSON.parse(raw) : { addNewlineAfterUrl: false, showCharCount: true, editOnShare: false };
     } catch {
-      return { addNewlineAfterUrl: false, showCharCount: false, editOnShare: false };
+      return { addNewlineAfterUrl: false, showCharCount: true, editOnShare: false };
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -69,6 +69,9 @@
   const settingCharcount = document.getElementById('setting-charcount');
   const charCountEl = document.getElementById('char-count');
   const appVersionEl = document.getElementById('app-version');
+  const licenseDialog = document.getElementById('license-dialog');
+  const btnLicense = document.getElementById('btn-license');
+  const btnLicenseClose = document.getElementById('btn-license-close');
   const quickShareDialog = document.getElementById('quick-share-dialog');
   const quickSharePreview = document.getElementById('quick-share-preview');
   const btnQuickShare = document.getElementById('btn-quick-share');
@@ -416,6 +419,22 @@
     settings.showCharCount = settingCharcount.checked;
     saveSettings(settings);
     updateCharCount();
+  });
+
+  // --- License dialog ---
+  btnLicense.addEventListener('click', function (e) {
+    e.preventDefault();
+    licenseDialog.classList.remove('hidden');
+  });
+
+  btnLicenseClose.addEventListener('click', function () {
+    licenseDialog.classList.add('hidden');
+  });
+
+  licenseDialog.addEventListener('click', function (e) {
+    if (e.target === licenseDialog) {
+      licenseDialog.classList.add('hidden');
+    }
   });
 
   memoText.addEventListener('input', updateCharCount);

--- a/index.html
+++ b/index.html
@@ -86,8 +86,8 @@
     <div class="settings-footer">
       <div id="app-version" class="settings-version"></div>
       <div class="settings-links">
-        <a href="https://x.com/ilolio" target="_blank" rel="noopener noreferrer">お問い合わせ（開発者）</a>
-        <a href="#" id="btn-license">使用ライブラリのライセンス</a>
+        <a href="https://x.com/ilolio" target="_blank" rel="noopener noreferrer">開発者SNS（質問や意見、感想などもどうぞ）</a>
+        <a href="#" id="btn-license">使用ライブラリ</a>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
       <div id="app-version" class="settings-version"></div>
       <div class="settings-links">
         <a href="https://x.com/ilolio" target="_blank" rel="noopener noreferrer">お問い合わせ（開発者）</a>
-        <a href="https://github.com/twitter/twitter-text/blob/master/LICENSE" target="_blank" rel="noopener noreferrer">使用ライブラリのライセンス</a>
+        <a href="#" id="btn-license">使用ライブラリのライセンス</a>
       </div>
     </div>
   </div>
@@ -101,6 +101,23 @@
         <button id="btn-quick-post-x" class="action-btn action-btn-x" type="button">Xでポスト</button>
       </div>
       <button id="btn-quick-edit" class="btn btn-secondary quick-share-edit-btn" type="button">テキストを編集</button>
+    </div>
+  </div>
+
+  <!-- ライセンスモーダル -->
+  <div id="license-dialog" class="dialog-overlay hidden">
+    <div class="dialog license-dialog">
+      <h2 class="license-dialog-title">使用ライブラリ</h2>
+      <div class="license-list">
+        <div class="license-item">
+          <div class="license-item-name">twitter-text</div>
+          <div class="license-item-desc">X（Twitter）の文字数カウントに使用</div>
+          <a href="https://github.com/twitter/twitter-text/blob/master/LICENSE" target="_blank" rel="noopener noreferrer">Apache License 2.0</a>
+        </div>
+      </div>
+      <div class="dialog-actions">
+        <button id="btn-license-close" class="btn btn-secondary" type="button">閉じる</button>
+      </div>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -85,6 +85,10 @@
     </div>
     <div class="settings-footer">
       <div id="app-version" class="settings-version"></div>
+      <div class="settings-links">
+        <a href="https://x.com/ilolio" target="_blank" rel="noopener noreferrer">お問い合わせ（開発者）</a>
+        <a href="https://github.com/twitter/twitter-text/blob/master/LICENSE" target="_blank" rel="noopener noreferrer">使用ライブラリのライセンス</a>
+      </div>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -525,3 +525,20 @@ header h1 {
   font-size: 13px;
   color: var(--text-secondary);
 }
+
+.settings-links {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.settings-links a {
+  font-size: 13px;
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.settings-links a:active {
+  text-decoration: underline;
+}

--- a/style.css
+++ b/style.css
@@ -542,3 +542,51 @@ header h1 {
 .settings-links a:active {
   text-decoration: underline;
 }
+
+/* License Dialog */
+.license-dialog {
+  max-width: 360px;
+}
+
+.license-dialog-title {
+  font-size: 17px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.license-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.license-item {
+  background: var(--bg);
+  border-radius: 8px;
+  padding: 12px 16px;
+}
+
+.license-item-name {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.license-item-desc {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.license-item a {
+  font-size: 13px;
+  color: var(--primary);
+  text-decoration: none;
+  margin-top: 6px;
+  display: inline-block;
+}
+
+.license-item a:active {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
This PR updates the settings page with new footer links and changes the default character count setting to enabled.

## Key Changes
- **Settings Footer Links**: Added two new links in the settings footer:
  - Contact link to the developer's X (Twitter) profile
  - License link for the twitter-text library used in the project
  - Styled with new `.settings-links` CSS classes for proper layout and appearance

- **Default Settings**: Changed the default value of `showCharCount` from `false` to `true` in both the initial load and error fallback cases in `loadSettings()`

## Implementation Details
- New CSS classes added for the settings links container and link styling:
  - `.settings-links`: Flexbox column layout with 12px gap and 16px top margin
  - `.settings-links a`: 13px font size, primary color, no text decoration
  - `.settings-links a:active`: Underline on active state
- Links open in new tabs with `target="_blank"` and `rel="noopener noreferrer"` for security
- Character count feature is now enabled by default for new users and when settings fail to load

https://claude.ai/code/session_01AmHmpZbjNQdhhB3qbwJnWs